### PR TITLE
Disallow opening read-only on Android API <= 15

### DIFF
--- a/SolutionVersion.cs
+++ b/SolutionVersion.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
 
-[assembly: AssemblyVersion("2.11.0.0")]
-[assembly: AssemblyFileVersion("2.11.0.0")]
-[assembly: AssemblyInformationalVersion("2.11.0")]
+[assembly: AssemblyVersion("2.11.1.0")]
+[assembly: AssemblyFileVersion("2.11.1.0")]
+[assembly: AssemblyInformationalVersion("2.11.1")]


### PR DESCRIPTION
Fixes "EntryPointNotFoundException: sqlite3_db_readonly"