### PR TITLE
Use DateTimeStyles.AdjustToUniversal.

### DIFF
--- a/src/System.Data.SQLite/SQLiteDataReader.cs
+++ b/src/System.Data.SQLite/SQLiteDataReader.cs
@@ -441,7 +441,7 @@ namespace System.Data.SQLite
 			case SQLiteColumnType.Text:
 				int stringLength = NativeMethods.sqlite3_column_bytes(m_currentStatement, ordinal);
 				string stringValue = SQLiteConnection.FromUtf8(NativeMethods.sqlite3_column_text(m_currentStatement, ordinal), stringLength);
-				return dbType == DbType.DateTime ? (object) DateTime.ParseExact(stringValue, s_dateTimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None) :
+				return dbType == DbType.DateTime ? (object) DateTime.ParseExact(stringValue, s_dateTimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AdjustToUniversal) :
 					(object) stringValue;
 
 			default:


### PR DESCRIPTION
Using `DateTimeStyles.AdjustToUniversal` instead of `DateTimeStyles.None` returns a correct but converted-to-`Local` time (not `Unspecified`) if a `Utc` time was saved (which would have caused a `Z` to be appended). (Behavior if a `Local` or `Unspecified` time was saved is not changed by `DateTimeStyles.AdjustToUniversal`, i.e. it still returns Unspecified in both cases.)