### PR TITLE
Fix AppDomainUnloadedException in SQLiteLog

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);1591;1998</NoWarn>

--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -1,5 +1,12 @@
 # Version History
 
+## 3.2.0
+
+* `SQLiteLog` only calls `sqlite3_config` to initialize logging when an event handler is attached to `SQLiteLog.Log`.
+  * It is no longer called automatically from the `SQLiteConnection` constructor. This fixes a `TypeInitializationException` and `AppDomainUnloadedException` in `SQLiteLog`.
+  * If you are using `SQLiteLog.Log`, you _must_ attach an event handler before calling any other methods of this library. This is a [limitation of SQLite](https://www.sqlite.org/c3ref/config.html).
+  * If other methods in this library are used before `SQLiteLog.Log`, the native event handler will fail to be installed properly, and no `Log` events will be raised. 
+
 ## 3.1.0
 
 * Support `JournalSizeLimit` and `PersistWal` connection string options.

--- a/src/System.Data.SQLite/SQLiteConnection.cs
+++ b/src/System.Data.SQLite/SQLiteConnection.cs
@@ -13,7 +13,6 @@ namespace System.Data.SQLite
 	{
 		public SQLiteConnection()
 		{
-			SQLiteLog.Initialize();
 			m_transactions = new Stack<SQLiteTransaction>();
 		}
 

--- a/tests/System.Data.SQLite.Tests/SetUpFixture.cs
+++ b/tests/System.Data.SQLite.Tests/SetUpFixture.cs
@@ -1,0 +1,22 @@
+using NUnit.Framework;
+
+namespace System.Data.SQLite.Tests
+{
+	[SetUpFixture]
+	public class MySetUpClass
+	{
+		[OneTimeSetUp]
+		public void OneTimeSetUp()
+		{
+			// Access this property so that sqlite3_config is called, which needs to happen before any other sqlite3_* method calls.
+			// This is necessary because SqliteTests.SubscribeUnsubscribeLog attaches an event handler to this property, which
+			// won't work if it's not the first SQLite code that's run in a process.
+			SQLiteLog.Log += Handler;
+			SQLiteLog.Log -= Handler;
+
+			static void Handler(object sender, LogEventArgs e)
+			{
+			}
+		}
+	}
+}

--- a/tests/System.Data.SQLite.Tests/SqliteCommandTests.cs
+++ b/tests/System.Data.SQLite.Tests/SqliteCommandTests.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using NUnit.Framework;
 
 namespace System.Data.SQLite.Tests


### PR DESCRIPTION
`SQLiteLog` only calls `sqlite3_config` to initialize logging when an event handler is attached to `SQLiteLog.Log`.

* It is no longer called automatically from the `SQLiteConnection` constructor. This fixes a `TypeInitializationException` and `AppDomainUnloadedException` in `SQLiteLog`.
* If you are using `SQLiteLog.Log`, you _must_ attach an event handler before calling any other methods of this library. This is a [limitation of SQLite](https://www.sqlite.org/c3ref/config.html).