### PR TITLE
Make the `Sql` property lazy

### DIFF
--- a/src/System.Data.SQLite/SQLiteConnection.cs
+++ b/src/System.Data.SQLite/SQLiteConnection.cs
@@ -335,7 +335,7 @@ namespace System.Data.SQLite
 #elif XAMARIN_IOS
 		[ObjCRuntime.MonoPInvokeCallback(typeof(SQLiteTraceV2Callback))]
 #endif
-		private static unsafe void ProfileCallback(SQLiteTraceEvents eventCode, IntPtr userData, IntPtr pStmt, IntPtr pDuration)
+		private static void ProfileCallback(SQLiteTraceEvents eventCode, IntPtr userData, IntPtr pStmt, IntPtr pDuration)
 		{
 			var handle = GCHandle.FromIntPtr(userData);
 			var connection = (SQLiteConnection) handle.Target;

--- a/src/System.Data.SQLite/StatementCompletedEventArgs.cs
+++ b/src/System.Data.SQLite/StatementCompletedEventArgs.cs
@@ -5,12 +5,16 @@ namespace System.Data.SQLite
 	/// </summary>
 	public sealed class StatementCompletedEventArgs : EventArgs
 	{
+#if NET5_0
 		/// <summary>
 		/// The SQL of the statement that was executed.
 		/// </summary>
-#if NET5_0
+		/// <remarks>This property is only valid to read during the event handler callback. (Once read, the string can be cached.)</remarks>
 		public string Sql => m_sql ??= SQLiteConnection.FromUtf8(m_sqlPointer);
 #else
+		/// <summary>
+		/// The SQL of the statement that was executed.
+		/// </summary>
 		public string Sql { get; }
 #endif
 

--- a/src/System.Data.SQLite/StatementCompletedEventArgs.cs
+++ b/src/System.Data.SQLite/StatementCompletedEventArgs.cs
@@ -8,18 +8,35 @@ namespace System.Data.SQLite
 		/// <summary>
 		/// The SQL of the statement that was executed.
 		/// </summary>
+#if NET5_0
+		public string Sql => m_sql ??= SQLiteConnection.FromUtf8(m_sqlPointer);
+#else
 		public string Sql { get; }
+#endif
 
 		/// <summary>
 		/// The time it took to execute the statement.
 		/// </summary>
 		public TimeSpan Time { get; }
 
+#if NET5_0
+		internal StatementCompletedEventArgs(IntPtr sql, TimeSpan time)
+#else
 		internal StatementCompletedEventArgs(string sql, TimeSpan time)
+#endif
 		{
+#if NET5_0
+			m_sqlPointer = sql;
+#else
 			Sql = sql;
+#endif
 			Time = time;
 		}
+
+#if NET5_0
+		private readonly IntPtr m_sqlPointer;
+		private string m_sql;
+#endif
 	}
 
 	/// <summary>


### PR DESCRIPTION
This avoids an unnecessary conversion from UTF-8 to a string (and resultant garbage) if the event subscriber first checks the `Time` property and takes no action if it's sufficiently small.
