### PR TITLE
Use `stackalloc` and `Span<byte>` to reduce allocations

### DIFF
--- a/src/System.Data.SQLite/NativeMethods.cs
+++ b/src/System.Data.SQLite/NativeMethods.cs
@@ -37,10 +37,18 @@ namespace System.Data.SQLite
 		public static extern SQLiteErrorCode sqlite3_bind_null(SqliteStatementHandle stmt, int ordinal);
 
 		[DllImport(c_dllName, CallingConvention = c_callingConvention)]
+#if NET5_0
+		public static extern unsafe int sqlite3_bind_parameter_index(SqliteStatementHandle stmt, byte* zName);
+#else
 		public static extern int sqlite3_bind_parameter_index(SqliteStatementHandle stmt, byte[] zName);
+#endif
 
 		[DllImport(c_dllName, CallingConvention = c_callingConvention)]
+#if NET5_0
+		public static extern unsafe SQLiteErrorCode sqlite3_bind_text(SqliteStatementHandle stmt, int ordinal, byte* value, int count, IntPtr free);
+#else
 		public static extern SQLiteErrorCode sqlite3_bind_text(SqliteStatementHandle stmt, int ordinal, byte[] value, int count, IntPtr free);
+#endif
 
 		[DllImport(c_dllName, CallingConvention = c_callingConvention)]
 		public static extern SQLiteErrorCode sqlite3_busy_timeout(SqliteDatabaseHandle db, int ms);

--- a/tests/System.Data.SQLite.Tests/System.Data.SQLite.Tests.csproj
+++ b/tests/System.Data.SQLite.Tests/System.Data.SQLite.Tests.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Platform)' != 'win-x64' and '$(Platform)' != 'win-x86' and '$(Platform)' != 'osx-x64' ">
-    <TargetFrameworks>netcoreapp3.1;net472;xamarin.ios10;monoandroid81</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net5.0;xamarin.ios10;monoandroid81</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Platform)' == 'win-x64' ">
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472;net5.0</TargetFrameworks>
     <RuntimeIdentifier>$(Platform)</RuntimeIdentifier>
   </PropertyGroup>
 
@@ -29,6 +29,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Platform)' == 'everything' and '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <RuntimeIdentifiers>win-x64;osx-x64</RuntimeIdentifiers>
+    <ExtrasBuildEachRuntimeIdentifier>true</ExtrasBuildEachRuntimeIdentifier>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Platform)' == 'everything' and '$(TargetFramework)' == 'net5.0' ">
     <RuntimeIdentifiers>win-x64;osx-x64</RuntimeIdentifiers>
     <ExtrasBuildEachRuntimeIdentifier>true</ExtrasBuildEachRuntimeIdentifier>
   </PropertyGroup>


### PR DESCRIPTION
Avoid creating temporary garbage byte arrays for short strings.
