### PR TITLE
Add `BeginTransaction(bool deferred)` overload

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>3.3.4</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);1591;1998</NoWarn>

--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 3.4.0
+
+* Add `SQLiteConnection.BeginTransaction(bool deferred)`: [#53](https://github.com/Faithlife/System.Data.SQLite/pull/53).
+
 ## 3.3.4
 
 * Improve efficiency of calling `IsDBNull` then `GetValue` (for the same field).


### PR DESCRIPTION
This provides a clear way to use SQLite's `BEGIN` (as opposed to `BEGIN IMMEDIATE`) functionality: https://www.sqlite.org/lang_transaction.html

It's modeled on the public API in Microsoft.Data.Sqlite: https://github.com/dotnet/efcore/blob/3b196063269f37d07324084e7ebb8dc641ad10d4/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs#L505-L506